### PR TITLE
add the missing import brl.threads, so the code can compile.

### DIFF
--- a/samples/threads/background_loading.bmx
+++ b/samples/threads/background_loading.bmx
@@ -7,6 +7,7 @@ Framework SDL.gl2sdlmax2d
 ?
 Import brl.pngloader
 Import brl.map
+Import brl.threads
 
 ' -----------------------------------------------------------------------------
 ' MAKE SURE "Threaded Build" IS CHECKED IN THE Program -> Build Options menu!


### PR DESCRIPTION
So, the example "background_loading.bmx" inside "threads" wasn't compiling. Adds the missing import "brl.threads" and it works!