### PR TITLE
Exclude struct methods/functions from keyword creation

### DIFF
--- a/src/docmods/bmxtoker.bmx
+++ b/src/docmods/bmxtoker.bmx
@@ -384,6 +384,8 @@ Type TBmxToker
 		kw "final",T_FINAL
 		kw "module",T_MODULE
 		kw "moduleinfo",T_MODULEINFO
+		kw "struct",T_TYPE
+		kw "endstruct",T_ENDTYPE
 	End Function	
 	
 	Function Create:TBmxToker( url:Object )

--- a/src/docmods/docmods.bmx
+++ b/src/docmods/docmods.bmx
@@ -123,8 +123,11 @@ Function SyncDocs( docs:TDocs )
 			Local turl$=url+"#"+p.ident
 			TPrint "&nbsp;<a class=navsmall href="+turl+" target=main>"+p.ident+"</a><br>"
 			index.AddLast p.ident+":"+turl
-			Local i=p.proto.Find( " " )
-			If i<>-1 comms.AddLast p.proto[i+1..].Trim()+"|"+turl[5..]
+			
+			If p.kind <> T_METHOD
+				Local i=p.proto.Find( " " )
+				If i<>-1 comms.AddLast p.proto[i+1..].Trim()+"|"+turl[5..]
+			EndIf
 		Next
 		TPrint "</div>"
 


### PR DESCRIPTION
Perhaps not a proper solution, but it does the job.

(STomlDateTime.time for example created the time keyword)